### PR TITLE
fix in BOLTS_version function for OpenSCAD

### DIFF
--- a/backends/openscad.py
+++ b/backends/openscad.py
@@ -93,7 +93,7 @@ class OpenSCADExporter(BackendExporter):
 		version_fid = open(join(out_path,"common","version.scad"),"w","utf8")
 		if stable:
 			major, minor = str(version).split('.')
-			version_fid.write('function BOLTS_version() = [%s, %s, %s];\n' %
+			version_fid.write('function BOLTS_version() = [%s, %s, "%s"];\n' %
 				 (major, minor, target_license))
 		else:
 			version_fid.write('function BOLTS_version() = "%s";\n' % version)


### PR DESCRIPTION
In OpenSCAD 2014.03 the string 'LGPL 2.1' which was not encapsulated with quotation marks caused a syntax error. I am not sure if this was a problem with older versions of OpenSCAD.
