### PR TITLE
[openscad] [extrusions] - Add detailed parameter in tslot20x20_2sa metadata

### DIFF
--- a/openscad/extrusions/extrusions.base
+++ b/openscad/extrusions/extrusions.base
@@ -26,7 +26,7 @@
         defaults: {detailed: false}
       classids: [tslot20x20_2s]
     - name: tslot_20x20_2sa_base
-      arguments: [l]
+      arguments: [l, detailed]
       parameters:
         free: [detailed]
         types: {detailed: Bool}


### PR DESCRIPTION

Fixes #212 

**Changes**

- Add `detailed` in `tslot20x20_2sa` metadata so that `tslot_20x20_2sa_base` be invoked correctly by generated module source code.

