### PR TITLE
Fix various typos

### DIFF
--- a/backends/common.py
+++ b/backends/common.py
@@ -132,7 +132,7 @@ class Backend:
                 join(self.bout_path, "data", "%s.blt" % coll.id)
             )
 
-            # geoemtry data files
+            # geometry data files
             if isdir(join(self.repo.path, "data", "%s" % coll.id)):
                 copytree(
                     join(self.repo.path, "data", "%s" % coll.id),
@@ -144,7 +144,7 @@ class Backend:
             if all_data is True:
                 print(
                     "Setting all_data is: {}. Thus skip copy of "
-                    "geoemtry creation module {}.base due to "
+                    "geometry creation module {}.base due to "
                     .format(all_data, coll.id)
                 )
                 continue

--- a/backends/common/repo_tools.py
+++ b/backends/common/repo_tools.py
@@ -157,11 +157,11 @@ import boltspy as bolts
 
 
 # ************************************************************************************************
-# acces the repo
+# access the repo
 #
 # each *.blt file in data directory is a collection
 # a collections consists of classes
-# class and collection ids are uniqe in the entire repo
+# class and collection ids are unique in the entire repo
 # two possibilities to access them
 # the use of repo attributes or repo iterators
 

--- a/backends/errors.py
+++ b/backends/errors.py
@@ -23,7 +23,7 @@ class BackendError(Exception):
     def __str__(self):
         return "Problem in backend %s:\n" + self.msg
 
-class UncommitedChangesError(Exception):
+class UncommittedChangesError(Exception):
     def __str__(self):
         return "There are uncommitted changes in the git repo"
 

--- a/backends/freecad/init.py
+++ b/backends/freecad/init.py
@@ -112,7 +112,7 @@ def add_part_by_classid(classid, in_params=None):
 
         in_params:
             - dictionary of all free Parameters
-            - if ommited, the default parameters are taken (see Default in *.blt file)
+            - if omitted, the default parameters are taken (see Default in *.blt file)
             - if a key is missing in Parameter, the default is added
             - get the default parameters by BOLTS.get_default_params(SaveClassName)
             - if the key "name" is given, this will be used as FreeCAD object name
@@ -138,7 +138,7 @@ def add_part_by_name(save_class_name, in_params=None):
 
         in_params:
             - dictionary of all free Parameters
-            - if ommited, the default parameters are taken (see Default in *.blt file)
+            - if omitted, the default parameters are taken (see Default in *.blt file)
             - if a key is missing in Parameter, the default is added
             - get the default parameters by BOLTS.get_default_params(SaveClassName)
             - if the key "name" is given, this will be used as FreeCAD object name
@@ -164,7 +164,7 @@ def add_part_by_standard(save_standard_name, in_params=None):
 
         in_params:
             - dictionary of all free Parameters
-            - if ommited, the default parameters are taken (see Default in *.blt file)
+            - if omitted, the default parameters are taken (see Default in *.blt file)
             - if a key is missing in Parameter, the default is added
             - get the default parameters by BOLTS.get_default_params(SaveClassName)
             - if the key "name" is given, this will be used as FreeCAD object name

--- a/backends/website/blog/posts/2013-09-05-BOLTS-page.md
+++ b/backends/website/blog/posts/2013-09-05-BOLTS-page.md
@@ -15,6 +15,6 @@ it with an [appropriate
 picture](https://www.flickr.com/photos/dkpphotography/9468970843)
 by [Dhruv Patel](https://www.flickr.com/photos/dkpphotography/).
 
-The content of this page is mostly non-existant, this will (hopefully change in
+The content of this page is mostly non-existent, this will (hopefully change in
 the future).
 

--- a/backends/website/blog/posts/2013-09-24-Comments.md
+++ b/backends/website/blog/posts/2013-09-24-Comments.md
@@ -16,7 +16,7 @@ included) and there is a download page with current development snapshots.
 
 The most spectacular part however is the overview over the parts that are
 contained in BOLTS right now. You can access the different standards, read the
-tables and look at non-existant or very ugly drawings. So actually it is not so
+tables and look at non-existent or very ugly drawings. So actually it is not so
 spectacular, but all this is generated from the very same data that also fuels
 BOLTS for OpenSCAD and FreeCAD, so it can serve as a always up-to-date
 reference on the available parts.

--- a/backends/website/blog/posts/2013-11-29-BLT-file-progress.md
+++ b/backends/website/blog/posts/2013-11-29-BLT-file-progress.md
@@ -5,7 +5,7 @@
 
 This post should now appear on [Planet RepRap](http://planet.arcol.hu/), hi everybody reading this from there. This is the development blog for [BOLTS]({{ url(main.index) }}). BOLTS tries to build an open standard parts library for a number of CAD applications.
 
-BOLTS is a rather young project, but is already useable with [OpenSCAD](http://www.openscad.org/) and [FreeCAD](http://freecadweb.org/). Its youth is noticeable by the still relatively [small number of parts]({{ url(parts.index) }})), though. It is not difficult to add more parts and [well documented]({{ url(docs.index) }}), so if you are missing a part in BOLTS, or just think BOLTS is a good idea, [please help out with improving it]({{ url(main.contribute) }}).
+BOLTS is a rather young project, but is already usable with [OpenSCAD](http://www.openscad.org/) and [FreeCAD](http://freecadweb.org/). Its youth is noticeable by the still relatively [small number of parts]({{ url(parts.index) }})), though. It is not difficult to add more parts and [well documented]({{ url(docs.index) }}), so if you are missing a part in BOLTS, or just think BOLTS is a good idea, [please help out with improving it]({{ url(main.contribute) }}).
 
 If you want to try out BOLTS or learn more about it, you should head to its [webpage]({{ url(main.index) }}).
 

--- a/backends/website/blog/posts/2014-04-23-Beaming.md
+++ b/backends/website/blog/posts/2014-04-23-Beaming.md
@@ -30,7 +30,7 @@ ordinary part.
 During this effort we uncovered a fair amount of problems with BOLTS, like
 issues with names and standards and the BOLTS GUI in FreeCAD, that will have to
 be addressed. But that was somehow expected at this still quite early stage of
-develoment.
+development.
 
 If you want to testdrive this, you can grab the latest development snapshot
 from the [webpage](http://jreinhardt.github.io/BOLTS/index.html). This will

--- a/backends/website/blog/posts/2014-09-10-New-Webpage.md
+++ b/backends/website/blog/posts/2014-09-10-New-Webpage.md
@@ -19,7 +19,7 @@ New url
 BOLTS now has a proper and more memorable domain at
 [bolts-library.org](http://bolts-library.org), instead of a relatively
 complicated github.io url. I had to take a domain with a additional suffix, as
-bolts alone was already taken in every useful top level domain. Thats the
+bolts alone was already taken in every useful top level domain. That's the
 disadvantage if you choose an acronyme for a project that is also a real word.
 
 Responsive Design
@@ -97,11 +97,11 @@ you can easily select the result that you are interested in.
 Versioned Documentation
 -----------------------
 
-Now the documentaion for multiple versions of BOLTS can be accessed separately.
+Now the documentation for multiple versions of BOLTS can be accessed separately.
 With the old setup, a common problem was, that the documentation was updated
 for the current development version of BOLTS, and therefore differed
 significantly from what people actually had installed, which was confusing. Now
-the documentation for the stable relaease and the development version can be
+the documentation for the stable release and the development version can be
 accessed separately
 
 At the moment however, the documentation for the development version is not
@@ -123,7 +123,7 @@ the development of BOLTS.
 
 This stack will also allow for further experiments, improvements and
 extensions. For example it will be very easy to expose a REST API to all the
-data BOLTS nows about, to allow other application to easily obtain informations
+data BOLTS nows about, to allow other application to easily obtain information
 about standard parts.
 
 Better Workflow
@@ -147,6 +147,6 @@ There are a few small disadvantages though. Due to the migration all the Google
 credit that the old page had accumulated is lost, so at the moment it is a bit
 more difficult to find the new website by googling.
 
-And everytime I push an update to the homepage, there is roughly half a minute
+And every time I push an update to the homepage, there is roughly half a minute
 downtime. It is possible to avoid this, but this requires a few changes to the
 app, and I have not yet tackled that.

--- a/backends/website/blog/posts/2021-09-06-PythonPackage distribution.md
+++ b/backends/website/blog/posts/2021-09-06-PythonPackage distribution.md
@@ -13,9 +13,9 @@ Development hast been continued after a long time of only rare development.
 
 * A very nasty problem in the regard of imports on all operating systems
   has been fixed for FreeCAD backend.
-* A lot of code formating has taken place.
-* On a few places it was moved to some more generic aproach.
+* A lot of code formatting has taken place.
+* On a few places it was moved to some more generic approach.
   Thus duplicate code was deleted.
-* A new distribution PythonPackage for the use without any CAD has been develped.
+* A new distribution PythonPackage for the use without any CAD has been developed.
 * On osarch is a topic with lots of interesting posts.
   See [Profile Section Libraries for Structural Engineering and beyond!](https://community.osarch.org/discussion/524/profile-section-libraries-for-structural-engineering-and-beyond/)

--- a/backends/website/docs/sources/0.3/freecad/basefcstd.md
+++ b/backends/website/docs/sources/0.3/freecad/basefcstd.md
@@ -58,7 +58,7 @@ directory of the repository.
 
 ### Write the base file
 
-The base file provides BOLTS with all the informations it needs to know about
+The base file provides BOLTS with all the information it needs to know about
 the files in a collection directory.
 
 For the aluminum extrusion it looks like this:
@@ -116,11 +116,11 @@ part and the `Height` property of the feature `Box` should be set to the length
 A parameter might appear more than once if more than one feature needs to be
 adjusted.
 
-The optional source field allows to give informations about the origin of the
+The optional source field allows to give information about the origin of the
 file. So if there is a URL from which this file was downloaded, this can be
 included here.
 
-When working on base files, pay attention to whitespace and identation and do
+When working on base files, pay attention to whitespace and indentation and do
 not use tabs.
 
 ### Test it

--- a/backends/website/docs/sources/0.3/freecad/basefunction.md
+++ b/backends/website/docs/sources/0.3/freecad/basefunction.md
@@ -13,7 +13,7 @@ the [FreeCAD documentation on this topic](http://freecadweb.org/wiki/index.php?t
 
 ### The function
 
-As an example we  use the follwing function to create washers:
+As an example we  use the following function to create washers:
 
     import Part
 
@@ -54,7 +54,7 @@ this collection (in this case `washer.base`).
 
 ### Write the base file
 
-The base file provides BOLTS with all the informations it needs to know about
+The base file provides BOLTS with all the information it needs to know about
 the files in a collection directory, it is a kind of manifest file. It contains
 a list of sections (more precisely 
 [base file elements]({{ spec(base-file-element) }}))
@@ -77,7 +77,7 @@ The begin of a new element is indicated by a hyphen. If there are more than
 one file in the collection directory, there would be more elements, but here
 it is only one.
 
-The base file element gives informations about the file like the filename,
+The base file element gives information about the file like the filename,
 the author and the license under which it is published.
 
 The line `type: function` indicates that it contains python functions for
@@ -86,7 +86,7 @@ follows, that describe the individual functions. In our case there is only
 one, called washer1.
 
 There is the possibility to add an optional `source` field which allows to give
-informations about the origin of the file. If there is a URL from which this
+information about the origin of the file. If there is a URL from which this
 file was downloaded, this can be included here.
 
 The `classids` field contains a list of classids to which this function
@@ -96,7 +96,7 @@ a single entry. Be careful, that the parameter names for all classes in this
 list must be the same, otherwise the parameter dict contains unexpected
 entries or names can not be found.
 
-When working on base files, pay attention to whitespace and identation and do
+When working on base files, pay attention to whitespace and indentation and do
 not use tabs.
 
 ### Testing
@@ -118,7 +118,7 @@ If BOLTS is started successfully, try adding the newly added part to the
 current document with different combinations of parameters.
 
 If nothing happens when you try to add the file, there is probably an error
-occuring during the execution of the function. Such errors are suppressed by
+occurring during the execution of the function. Such errors are suppressed by
 the gui system, so that no error messages are displayed. You can circumvent
 this by activating the `Add part` button manually. To do this type
 

--- a/backends/website/docs/sources/0.3/freecad/usage.md
+++ b/backends/website/docs/sources/0.3/freecad/usage.md
@@ -23,7 +23,7 @@ The available parts are sorted in two ways:
 2. by the standardization organisation if standardized
 
 By expanding the tree one can browse through the available parts. In the area
-between the treeview and the button informations about the current selection
+between the treeview and the button information about the current selection
 are displayed.
 
 [<img alt="Expanded treeview" src="{{ static(partsselector2.png) }}" />]({{ static(partsselector2.png) }})

--- a/backends/website/docs/sources/0.3/general/blt-files.md
+++ b/backends/website/docs/sources/0.3/general/blt-files.md
@@ -166,7 +166,7 @@ parameter names because they can also appear on drawings.
 
 We also give sensible default values for the free parameters.
 
-Finally, the source field should be used to explain where the informations come
+Finally, the source field should be used to explain where the information come
 from on which this class is built. In this case we do not really need it, but
 this becomes very important when building classes for standards.
 
@@ -220,7 +220,7 @@ The class for DIN11850 looks like this
         source: de.wikipedia.org/wiki/Rohr_(Technik)#Abmessungen
 
 As this class follows a standard the id is not shown to the user, so unique but
-slighly bulky id is used. The first new thing in this class is the standard
+slightly bulky id is used. The first new thing in this class is the standard
 field. The reason why not the id is used to encode the standard is that very
 often there are equivalent standards issued by different organisations. In this
 case a list of standards can be given in the standard field, which saves you

--- a/backends/website/docs/sources/0.3/general/development.md
+++ b/backends/website/docs/sources/0.3/general/development.md
@@ -68,10 +68,10 @@ be attributed to you.
 There is a 
 [pretty good tutorial how to fork a repository](https://help.github.com/articles/fork-a-repo)
 on the [GitHub help pages](https://help.github.com/),
- where you can also find more informations about working with git and GitHub.
+ where you can also find more information about working with git and GitHub.
 
 The next steps are explained in the section about `Creating topic branches and
-commiting your work`.
+committing your work`.
 
 ### Checking out a local copy of BOLTS
 
@@ -93,9 +93,9 @@ a new directory named `BOLTS` will be created that contains the current
 development state.
 
 The next steps are explained in the section about `Creating topic branches and
-commiting your work`.
+committing your work`.
 
-### Creating topic branches and commiting your work
+### Creating topic branches and committing your work
 
 You now should have a local copy of BOLTS. Before you start making changes, you
 should create a new branch. There is a quite detailed description about
@@ -142,8 +142,8 @@ with
 
     git status
 
-you can get a list of changed files that will be commited and those that will
-not be commited. Finally, to commit the added changes use
+you can get a list of changed files that will be committed and those that will
+not be committed. Finally, to commit the added changes use
 
     git commit
 

--- a/backends/website/docs/sources/0.3/general/drawing.md
+++ b/backends/website/docs/sources/0.3/general/drawing.md
@@ -23,7 +23,7 @@ result.
 
 The main purpose of drawings in BOLTS is to give a quick visual explanation of
 the meaning of the parameters of the class. It is not a full-fledged technical
-drawing, whose purpose is to provide all the informations necessary to produce
+drawing, whose purpose is to provide all the information necessary to produce
 the part. Nevertheless we borrow some conventions and techniques from technical
 drawings.
 

--- a/backends/website/docs/sources/0.3/general/licensing.md
+++ b/backends/website/docs/sources/0.3/general/licensing.md
@@ -18,7 +18,7 @@ BOLTS consists of a number of different parts that work together in different wa
 
 * [bolttools](https://github.com/jreinhardt/bolttools) is a collection of python modules that handle various tasks and aspects of the processes in BOLTS: create HTML documentation, parse the blt and base files, perform consistency checks on the parts and assemble the different distributions (BOLTS for FreeCAD, BOLTS for OpenSCAD). bolttools is developed by me and licensed under the [LGPL 2.1 or later](http://www.gnu.org/licenses/old-licenses/lgpl-2.1).
 
-* the blt files are YAML files that contain not backend specific data and metadata about the part (more precisely about classes of parts, because there is often a large amount of redundancy). These files contain among other informations the tables with dimensions, and form the foundation of BOLTS. Its license is chosen by the creator.
+* the blt files are YAML files that contain not backend specific data and metadata about the part (more precisely about classes of parts, because there is often a large amount of redundancy). These files contain among other information the tables with dimensions, and form the foundation of BOLTS. Its license is chosen by the creator.
 
 * the backend specific data is specific to the CAD application (FreeCAD or OpenSCAD at the moment), and can come in two forms: as code (OpenSCAD modules or FreeCAD python functions) or as data (stl files for OpenSCAD or fcstd files for FreeCAD. Its license is chosen by the creator.
 
@@ -30,7 +30,7 @@ We want to focus on open source licenses, and luckily someone who knows [explain
 
 And when we take some content with a certain license A and process it with a program with a certain license B, what license C has the result?
 
-This is much easier to answer, and again I reference [people who know](http://www.gnu.org/licenses/gpl-faq.html#GPLOutput). The result has license A, unless very specifc conditions apply.
+This is much easier to answer, and again I reference [people who know](http://www.gnu.org/licenses/gpl-faq.html#GPLOutput). The result has license A, unless very specific conditions apply.
 
 ### Consequences for BOLTS distributions
 
@@ -66,13 +66,13 @@ I mentioned earlier, that there is application specific data in form of code and
 
 #### Backend specific data in form of code
 
-In this case on can consider the part as the result of a program (BOLTS), which is not affected by the license of the programm. So parts created by code (FreeCAD python functions and OpenSCAD modules) cause no licensing related restrictions on the resulting design.
+In this case on can consider the part as the result of a program (BOLTS), which is not affected by the license of the program. So parts created by code (FreeCAD python functions and OpenSCAD modules) cause no licensing related restrictions on the resulting design.
 
 #### Backend specific data in form of data
 
 In this case on has to consider the final design as a combined work between the part (in form of a FreeCAD fcstd file or a STL file) and the rest of the design that the user created. If the BOLTS part were licensed under a fairly restrictive license like GPL, the whole design would need to be licensed under the GPL.
 
-As this is undesireable, BOLTS must not contain backend specific data in form of data that causes such restrictions. This means, that such data must be placed in the public domain, or better yet, the author must waive all rights on this content using [CC0](http://creativecommons.org/about/cc0). The latter is a legally more sound procedure, as the public domain is a legal concept that does not exist in all legislations.
+As this is undesirable, BOLTS must not contain backend specific data in form of data that causes such restrictions. This means, that such data must be placed in the public domain, or better yet, the author must waive all rights on this content using [CC0](http://creativecommons.org/about/cc0). The latter is a legally more sound procedure, as the public domain is a legal concept that does not exist in all legislations.
 
 ### Consequences for BOLTS itself
 

--- a/backends/website/docs/sources/0.3/openscad/basemodule.md
+++ b/backends/website/docs/sources/0.3/openscad/basemodule.md
@@ -70,7 +70,7 @@ So in the case of the pipes collection `pipe.scad` is now in the directory
 ### Write the base file
 
 This collection directory must also contain the base file for this directory.
-The base file provides BOLTS with all the informations it needs to know about
+The base file provides BOLTS with all the information it needs to know about
 the files in a collection directory, it is a kind of manifest file. It
 contains a list of sections 
 (more precisely [base file elements]({{ spec(base-file-element) }})),
@@ -107,7 +107,7 @@ in this list must be the same, otherwise the some parameters can not be found
 for some classes.
 
 There is the possibility to add an optional `source` field which allows to give
-informations about the origin of the file. If there is a URL from which this
+information about the origin of the file. If there is a URL from which this
 file was downloaded, this can be included here.
 
 ### Testing

--- a/backends/website/docs/sources/0.3/openscad/usage.md
+++ b/backends/website/docs/sources/0.3/openscad/usage.md
@@ -27,7 +27,7 @@ over all parts that it provides. There one can browse through the different
 collections and check out which standards of a standardization body are
 available in BOLTS.
 
-Each part has a dedicated page, where one can find more detailed informations
+Each part has a dedicated page, where one can find more detailed information
 about this part, a drawing and tables with dimensions. The information that is
 most interesting for our purposes can be found in the section OpenSCAD. There
 it says either that the part is not available for OpenSCAD (in which case you
@@ -93,7 +93,7 @@ the [attach library](http://www.thingiverse.com/thing:30136).
 Instead of having complicated nested `translate` and `rotate` calls, this
 library allows to specify the position and orientation of a portion of a design
 using so called connectors. A connector is a data type that contains
-informations about both position and orientation.
+information about both position and orientation.
 
 A connector is created with the `new_cs` function, which takes two arguments: a
 vector with three values specifying the origin of the connector and a list of

--- a/backends/website/docs/sources/0.4/freecad/basefunction.md
+++ b/backends/website/docs/sources/0.4/freecad/basefunction.md
@@ -13,7 +13,7 @@ the [FreeCAD documentation on this topic](http://freecadweb.org/wiki/index.php?t
 
 ### The function
 
-As an example we  use the follwing function to create washers:
+As an example we  use the following function to create washers:
 
     import Part
 
@@ -54,7 +54,7 @@ this collection (in this case `washer.base`).
 
 ### Write the base file
 
-The base file provides BOLTS with all the informations it needs to know about
+The base file provides BOLTS with all the information it needs to know about
 the files in a collection directory, it is a kind of manifest file. It contains
 a list of sections (more precisely 
 [base file elements]({{ spec(base-file-element) }}))
@@ -77,7 +77,7 @@ The begin of a new element is indicated by a hyphen. If there are more than
 one file in the collection directory, there would be more elements, but here
 it is only one.
 
-The base file element gives informations about the file like the filename,
+The base file element gives information about the file like the filename,
 the author and the license under which it is published.
 
 The line `type: function` indicates that it contains python functions for
@@ -86,7 +86,7 @@ follows, that describe the individual functions. In our case there is only
 one, called washer1.
 
 There is the possibility to add an optional `source` field which allows to give
-informations about the origin of the file. If there is a URL from which this
+information about the origin of the file. If there is a URL from which this
 file was downloaded, this can be included here.
 
 The `classids` field contains a list of classids to which this function
@@ -96,7 +96,7 @@ a single entry. Be careful, that the parameter names for all classes in this
 list must be the same, otherwise the parameter dict contains unexpected
 entries or names can not be found.
 
-When working on base files, pay attention to whitespace and identation and do
+When working on base files, pay attention to whitespace and indentation and do
 not use tabs.
 
 ### Testing
@@ -118,7 +118,7 @@ If BOLTS is started successfully, try adding the newly added part to the
 current document with different combinations of parameters.
 
 If nothing happens when you try to add the file, there is probably an error
-occuring during the execution of the function. Such errors are suppressed by
+occurring during the execution of the function. Such errors are suppressed by
 the gui system, so that no error messages are displayed. You can circumvent
 this by activating the `Add part` button manually. To do this type
 

--- a/backends/website/docs/sources/0.4/freecad/usage.md
+++ b/backends/website/docs/sources/0.4/freecad/usage.md
@@ -23,7 +23,7 @@ The available parts are sorted in two ways:
 2. by the standardization organisation if standardized
 
 By expanding the tree one can browse through the available parts. In the area
-between the treeview and the button informations about the current selection
+between the treeview and the button information about the current selection
 are displayed.
 
 [<img alt="Expanded treeview" src="{{ static(partsselector2.png) }}" />]({{ static(partsselector2.png) }})

--- a/backends/website/docs/sources/0.4/general/blt-files.md
+++ b/backends/website/docs/sources/0.4/general/blt-files.md
@@ -166,7 +166,7 @@ parameter names because they can also appear on drawings.
 
 We also give sensible default values for the free parameters.
 
-Finally, the source field should be used to explain where the informations come
+Finally, the source field should be used to explain where the information come
 from on which this class is built. In this case we do not really need it, but
 this becomes very important when building classes for standards.
 
@@ -220,7 +220,7 @@ The class for DIN11850 looks like this
         source: de.wikipedia.org/wiki/Rohr_(Technik)#Abmessungen
 
 As this class follows a standard the id is not shown to the user, so unique but
-slighly bulky id is used. The first new thing in this class is the standard
+slightly bulky id is used. The first new thing in this class is the standard
 field. The reason why not the id is used to encode the standard is that very
 often there are equivalent standards issued by different organisations. In this
 case a list of standards can be given in the standard field, which saves you

--- a/backends/website/docs/sources/0.4/general/development.md
+++ b/backends/website/docs/sources/0.4/general/development.md
@@ -68,10 +68,10 @@ be attributed to you.
 There is a 
 [pretty good tutorial how to fork a repository](https://help.github.com/articles/fork-a-repo)
 on the [GitHub help pages](https://help.github.com/),
- where you can also find more informations about working with git and GitHub.
+ where you can also find more information about working with git and GitHub.
 
 The next steps are explained in the section about `Creating topic branches and
-commiting your work`.
+committing your work`.
 
 ### Checking out a local copy of BOLTS
 
@@ -93,9 +93,9 @@ a new directory named `BOLTS` will be created that contains the current
 development state.
 
 The next steps are explained in the section about `Creating topic branches and
-commiting your work`.
+committing your work`.
 
-### Creating topic branches and commiting your work
+### Creating topic branches and committing your work
 
 You now should have a local copy of BOLTS. Before you start making changes, you
 should create a new branch. There is a quite detailed description about
@@ -142,8 +142,8 @@ with
 
     git status
 
-you can get a list of changed files that will be commited and those that will
-not be commited. Finally, to commit the added changes use
+you can get a list of changed files that will be committed and those that will
+not be committed. Finally, to commit the added changes use
 
     git commit
 

--- a/backends/website/docs/sources/0.4/general/drawing.md
+++ b/backends/website/docs/sources/0.4/general/drawing.md
@@ -23,7 +23,7 @@ result.
 
 The main purpose of drawings in BOLTS is to give a quick visual explanation of
 the meaning of the parameters of the class. It is not a full-fledged technical
-drawing, whose purpose is to provide all the informations necessary to produce
+drawing, whose purpose is to provide all the information necessary to produce
 the part. Nevertheless we borrow some conventions and techniques from technical
 drawings.
 

--- a/backends/website/docs/sources/0.4/general/licensing.md
+++ b/backends/website/docs/sources/0.4/general/licensing.md
@@ -18,7 +18,7 @@ BOLTS consists of a number of different parts that work together in different wa
 
 * [bolttools](https://github.com/jreinhardt/bolttools) is a collection of python modules that handle various tasks and aspects of the processes in BOLTS: create HTML documentation, parse the blt and base files, perform consistency checks on the parts and assemble the different distributions (BOLTS for FreeCAD, BOLTS for OpenSCAD). bolttools is developed by me and licensed under the [LGPL 2.1 or later](http://www.gnu.org/licenses/old-licenses/lgpl-2.1).
 
-* the blt files are YAML files that contain not backend specific data and metadata about the part (more precisely about classes of parts, because there is often a large amount of redundancy). These files contain among other informations the tables with dimensions, and form the foundation of BOLTS. Its license is chosen by the creator.
+* the blt files are YAML files that contain not backend specific data and metadata about the part (more precisely about classes of parts, because there is often a large amount of redundancy). These files contain among other information the tables with dimensions, and form the foundation of BOLTS. Its license is chosen by the creator.
 
 * the backend specific data is specific to the CAD application (FreeCAD or OpenSCAD at the moment), and generally comes in form of code (OpenSCAD modules or FreeCAD python functions). Its license is chosen by the creator.
 
@@ -30,7 +30,7 @@ We want to focus on open source licenses, and luckily someone who knows [explain
 
 And when we take some content with a certain license A and process it with a program with a certain license B, what license C has the result?
 
-This is much easier to answer, and again I reference [people who know](http://www.gnu.org/licenses/gpl-faq.html#GPLOutput). The result has license A, unless very specifc conditions apply.
+This is much easier to answer, and again I reference [people who know](http://www.gnu.org/licenses/gpl-faq.html#GPLOutput). The result has license A, unless very specific conditions apply.
 
 ### Consequences for BOLTS distributions
 
@@ -64,7 +64,7 @@ This would be rather drastic, as that would severely limit the choice of license
 
 #### Backend specific data in form of code
 
-In this case on can consider the part as the result of a program (BOLTS), which is not affected by the license of the programm. So parts created by code (FreeCAD python functions and OpenSCAD modules) cause no licensing related restrictions on the resulting design.
+In this case on can consider the part as the result of a program (BOLTS), which is not affected by the license of the program. So parts created by code (FreeCAD python functions and OpenSCAD modules) cause no licensing related restrictions on the resulting design.
 
 ### Consequences for BOLTS itself
 

--- a/backends/website/docs/sources/0.4/openscad/basemodule.md
+++ b/backends/website/docs/sources/0.4/openscad/basemodule.md
@@ -70,7 +70,7 @@ So in the case of the pipes collection `pipe.scad` is now in the directory
 ### Write the base file
 
 This collection directory must also contain the base file for this directory.
-The base file provides BOLTS with all the informations it needs to know about
+The base file provides BOLTS with all the information it needs to know about
 the files in a collection directory, it is a kind of manifest file. It
 contains a list of sections 
 (more precisely [base file elements]({{ spec(base-file-element) }})),
@@ -107,7 +107,7 @@ in this list must be the same, otherwise the some parameters can not be found
 for some classes.
 
 There is the possibility to add an optional `source` field which allows to give
-informations about the origin of the file. If there is a URL from which this
+information about the origin of the file. If there is a URL from which this
 file was downloaded, this can be included here.
 
 ### Testing

--- a/backends/website/docs/sources/0.4/openscad/usage.md
+++ b/backends/website/docs/sources/0.4/openscad/usage.md
@@ -27,7 +27,7 @@ over all parts that it provides. There one can browse through the different
 collections and check out which standards of a standardization body are
 available in BOLTS.
 
-Each part has a dedicated page, where one can find more detailed informations
+Each part has a dedicated page, where one can find more detailed information
 about this part, a drawing and tables with dimensions. The information that is
 most interesting for our purposes can be found in the section OpenSCAD. There
 it says either that the part is not available for OpenSCAD (in which case you
@@ -93,7 +93,7 @@ the [attach library](http://www.thingiverse.com/thing:30136).
 Instead of having complicated nested `translate` and `rotate` calls, this
 library allows to specify the position and orientation of a portion of a design
 using so called connectors. A connector is a data type that contains
-informations about both position and orientation.
+information about both position and orientation.
 
 A connector is created with the `new_cs` function, which takes two arguments: a
 vector with three values specifying the origin of the connector and a list of

--- a/backends/website/docs/specs/blt_spec_0.1.rst
+++ b/backends/website/docs/specs/blt_spec_0.1.rst
@@ -24,7 +24,7 @@ These structures are specified below.
 Collection Header
 -----------------
 
-The collection header is an associative array that contains general informations regarding the Collection. It contains the following keys:
+The collection header is an associative array that contains general information regarding the Collection. It contains the following keys:
 
 - name: optional. A name for the collection.
 - description: optional. A description of the contents of this collection.
@@ -55,7 +55,7 @@ The parts list is a list of associative arrays, each describing a part. A part c
 -name: mandatory. A naming definition
 -url: optional. For standard parts the URL where the official standard can be bought.
 -table: optional. A table of dimensions.
--notes: optional. Notes for this part. This can be used to mention confusions, contradicting informations or missing data.
+-notes: optional. Notes for this part. This can be used to mention confusions, contradicting information or missing data.
 
 Names
 -----

--- a/backends/website/docs/specs/blt_spec_0.2.rst
+++ b/backends/website/docs/specs/blt_spec_0.2.rst
@@ -104,7 +104,7 @@ The backend directories
 =======================
 
 Each backend directory can contain files and directories with additional
-informations, which  are required by the backend. Details are specified by the
+information, which  are required by the backend. Details are specified by the
 backend_.
 
 **************************************
@@ -130,7 +130,7 @@ distribution.
    :width: 100%
 
 
-A example for a backend would be a process that uses the backend indepent data
+A example for a backend would be a process that uses the backend independent data
 about parts, their geometries and dimensions together with a number of
 templates and stylesheets and produces a set of HTML pages with a nicely
 rendered, browsable description of the parts. Other backends could produce data
@@ -139,13 +139,13 @@ that is suitable for use in specific CAD applications.
 Often backends are relatively independent and do use only their own backend
 specific data. However, this is not necessarily so, a backend may also use
 backend specific data of other backends. For example the HTML backend described
-above might add informations about how to use a part in a specific CAD
+above might add information about how to use a part in a specific CAD
 application, and this might require to access the backend specific data of the
 backend for this CAD application. However, such cross backend dependencies
 should be made optional, to keep every backend functional independently of other
 backends.
 
-There is a list-of-backends_, where more informations about the available
+There is a list-of-backends_, where more information about the available
 backends can be found and their base-files_ are specified.
 
 
@@ -173,7 +173,7 @@ collection ids: common, gui, template
 Collection header
 -----------------
 
-The collection header is an associative array that holds general informations
+The collection header is an associative array that holds general information
 regarding the collection_. It contains the following keys:
 
 - name: optional, string. A name for the collection.
@@ -220,7 +220,7 @@ class_. It has the following keys:
   urls has to be given.
 - notes: optional, string. Notes for this class. Can be used to formulate
   questions or additional information.
-- source: mandatory, string. A short description where the informations for this
+- source: mandatory, string. A short description where the information for this
   class originate. Should contain a URL if possible.
 
 .. _parameter-element:
@@ -347,13 +347,13 @@ base-file-element_, one for each file they describe.
 Base file element
 -----------------
 
-A base file element is an associative array containing informations about a
+A base file element is an associative array containing information about a
 file. Depending on the type of the file the contained keys are different.
 However, there are some keys that are present in every base file element:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_.
 - type: mandatory, string. A string describing the type of the file.
@@ -371,7 +371,7 @@ List of Backends
 OpenSCAD
 ********
 
-The files containing informations required by the OpenSCAD backend reside in
+The files containing information required by the OpenSCAD backend reside in
 the backend directory with the name openscad. This backend directory contains a
 folder for each collection_ that contains files related to this collection, and
 the folder is named like the collection-id.
@@ -379,7 +379,7 @@ the folder is named like the collection-id.
 The OpenSCAD backend generates a OpenSCAD library with modules for all parts
 from the collections.
 
-To be able to do that it needs informations about base modules, which are
+To be able to do that it needs information about base modules, which are
 stored in the base-files_ of a collection. Base modules are openscad modules
 that take as parameters a subset of all  the parameters of the part (see
 parameter-collection_), and construct the part according to these dimensions.
@@ -417,7 +417,7 @@ It is an associative array that contains the following keys:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_
 - type: "module"
@@ -441,7 +441,7 @@ the following keys:
 - classids: mandatory, list of string. A list of class ids for which this base
   module should be used.
 - parameters: optional, parameter-element_: Additional basespecific parameters.
-  These parameters allow to represent additional paramters, which are not
+  These parameters allow to represent additional parameters, which are not
   specific to the class, but to the base. This allows e.g. to let the user
   choose  between a detailed and a schematic representation of the part.
 
@@ -456,7 +456,7 @@ the STL format. It is an associative array with the following keys:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be either "CC0
   1.0" or "Public Domain".
 - type: "stl"
@@ -474,7 +474,7 @@ associative array with the following keys:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_.
 - type: "function"
@@ -492,7 +492,7 @@ with the following keys:
 - classids: mandatory, list of string. A list of class ids for which this base
   module should be used.
 - parameters: optional, parameter-element_: Additional basespecific parameters.
-  These parameters allow to represent additional paramters, which are not
+  These parameters allow to represent additional parameters, which are not
   specific to the class, but to the base. This allows e.g. to let the user
   choose  between a detailed and a schematic representation of the part.
 
@@ -507,7 +507,7 @@ associative array with the following keys:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be "CC0 1.0" or
   "Public Domain".
 - type: "fcstd"
@@ -525,7 +525,7 @@ Document. It has the following keys:
 - classids: mandatory, list of string. A list of class ids for which this base
   part should be used.
 - parameters: optional, parameter-element_: Additional basespecific parameters.
-  These parameters allow to represent additional paramters, which are not
+  These parameters allow to represent additional parameters, which are not
   specific to the class, but to the base. This allows e.g. to let the user
   choose  between a detailed and a schematic representation of the part.
 - proptoparam: optional, associative array of associative arrays. This maps

--- a/backends/website/docs/specs/blt_spec_0.3.rst
+++ b/backends/website/docs/specs/blt_spec_0.3.rst
@@ -84,7 +84,7 @@ The databases
 
 A database directory is a directory that contains data about certain aspects of
 the parts or data in a specific form.Backends can access this data to
-transform the parts data into specific forms or collect informations.
+transform the parts data into specific forms or collect information.
 
 In contrast to the data in the blt-file_, the data in the database directories
 is optional. If for a class_ this data is not available, the backend_ has to be
@@ -115,7 +115,7 @@ the distribution.
    :width: 100%
 
 
-Am example for a backend would be a process that uses the backend indepent data
+Am example for a backend would be a process that uses the backend independent data
 about parts, their geometries and dimensions together with a number of
 templates and stylesheets and produces a set of HTML pages with a nicely
 rendered, browsable description of the parts. Other backends could produce data
@@ -133,7 +133,7 @@ the extension .blt. These files contain exactly one YAML document consisting of
 an associative array with the following keys:
 
 - id: mandatory, string. The id of the collection. Must be identical to the
-  filename of the blt file without the extenstion.
+  filename of the blt file without the extension.
 - name: optional, string. A name for the collection.
 - description: optional, string. A description of the contents of this
   collection.
@@ -185,7 +185,7 @@ class_. It has the following keys:
   urls has to be given.
 - notes: optional, string. Notes for this class. Can be used to keep questions
   or additional information.
-- source: mandatory, string. A short description where the informations for this
+- source: mandatory, string. A short description where the information for this
   class originate. Should contain a URL if possible.
 
 .. _parameter-element:
@@ -354,7 +354,7 @@ properties) to populate the template given in the naming-element_.
 Base Files
 ==========
 
-Base files are `yaml <http://yaml.org/>`_ files, in which informations about
+Base files are `yaml <http://yaml.org/>`_ files, in which information about
 the files for a collection in a database_ directory are stored. They consist of
 a list of base-file-element_, one for each file they describe.
 
@@ -363,13 +363,13 @@ a list of base-file-element_, one for each file they describe.
 Base file element
 -----------------
 
-A base file element is an associative array containing informations about a
+A base file element is an associative array containing information about a
 file. Depending on the type of the file the contained keys are different.
 However, there are some keys that are present in every base file element:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_.
 - type: mandatory, string. A string describing the type of the file.
@@ -402,13 +402,13 @@ See base-file-type-drawing-dimensions_ and base-file-type-drawing-connectors_.
 OpenSCAD
 ********
 
-The files containing all the informations necessary to build a geometrical
+The files containing all the information necessary to build a geometrical
 representation of a class in OpenSCAD  reside in the "openscad" directory. This
 database directory contains a folder for each collection_ that contains files
 related to this collection, and the folder is named like the collection-id.
 
-To be able to do that it needs informations about base modules. These
-informations are stored in the base-files_ of a collection. Base modules are
+To be able to do that it needs information about base modules. These
+information are stored in the base-files_ of a collection. Base modules are
 OpenSCAD modules that take as parameters a subset of the parameters of the
 part (see parameter-collection_), and construct the part according to these
 dimensions.
@@ -471,7 +471,7 @@ parameters of a part. It is an associative array with the following keys:
   Files with the same basename but different extensions are taken to be
   conversions to different file formats.
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_.
 - type: "drawing-dimensions"
@@ -493,7 +493,7 @@ the following keys:
   Files with the same basename but different extensions are taken to be
   conversions to different file formats.
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_.
 - type: "drawing-connectors"
@@ -513,7 +513,7 @@ It is an associative array that contains the following keys:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_
 - type: "module"
@@ -536,10 +536,10 @@ the following keys:
 - classids: mandatory, list of string. A list of class ids for which this base
   module should be used.
 - parameters: optional, parameter-element_: Additional basespecific parameters.
-  These parameters allow to represent additional paramters, which are not
+  These parameters allow to represent additional parameters, which are not
   specific to the class, but to the base. This allows e.g. to let the user
   choose  between a detailed and a schematic representation of the part.
-- connectors: optional, base-module-cs_. Informations about the connectors
+- connectors: optional, base-module-cs_. Information about the connectors
   attached to the part.
 
 .. _base-module-cs:
@@ -573,7 +573,7 @@ the STL format. It is an associative array with the following keys:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be either "CC0
   1.0" or "Public Domain".
 - type: "stl"
@@ -591,7 +591,7 @@ associative array with the following keys:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_.
 - type: "function"
@@ -609,7 +609,7 @@ with the following keys:
 - classids: mandatory, list of string. A list of class ids for which this base
   module should be used.
 - parameters: optional, parameter-element_: Additional basespecific parameters.
-  These parameters allow to represent additional paramters, which are not
+  These parameters allow to represent additional parameters, which are not
   specific to the class, but to the base. This allows e.g. to let the user
   choose  between a detailed and a schematic representation of the part.
 
@@ -624,7 +624,7 @@ associative array with the following keys:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be "CC0 1.0" or
   "Public Domain".
 - type: "fcstd"
@@ -642,7 +642,7 @@ Document. It has the following keys:
 - classids: mandatory, list of string. A list of class ids for which this base
   part should be used.
 - parameters: optional, parameter-element_: Additional basespecific parameters.
-  These parameters allow to represent additional paramters, which are not
+  These parameters allow to represent additional parameters, which are not
   specific to the class, but to the base. This allows e.g. to let the user
   choose  between a detailed and a schematic representation of the part.
 - proptoparam: optional, associative array of associative arrays. This maps
@@ -665,7 +665,7 @@ create a design table that can be used together with a model file to create a
 
 - filename: mandatory, string. The filename of the SolidWorks model file
 - author: mandatory, string or list of strings. The author of the model file
-  with e-mail adress in <> or a list of several authors.
+  with e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_.
 - type: "solidworks"

--- a/backends/website/docs/specs/blt_spec_0.4.rst
+++ b/backends/website/docs/specs/blt_spec_0.4.rst
@@ -88,7 +88,7 @@ The databases
 
 A database directory is a directory that contains data about certain aspects of
 the parts or data in a specific form. Backends can access this data to
-transform the parts data into specific forms or collect informations.
+transform the parts data into specific forms or collect information.
 
 In contrast to the data in the blt-file_, the data in the database directories
 is optional. If for a class_ this data is not available, the backend_ has to be
@@ -119,7 +119,7 @@ the distribution of this backend.
    :width: 100%
 
 
-An example for a backend would be a process that uses the backend indepent data
+An example for a backend would be a process that uses the backend independent data
 about parts, their geometries and dimensions together with a number of
 templates and stylesheets and produces a set of HTML pages with a nicely
 rendered, browsable description of the parts. Other backends could produce data
@@ -137,7 +137,7 @@ containing `yaml <http://yaml.org/>`_ markup. These files contain exactly one
 YAML document consisting of an associative array with the following keys:
 
 - id: mandatory, string. The id of the collection. Must be identical to the
-  filename of the blt file without the extenstion.
+  filename of the blt file without the extension.
 - name: optional, string. A name for the collection.
 - description: optional, string. A description of the contents of this
   collection.
@@ -180,7 +180,7 @@ class_. It has the following keys:
   urls has to be given.
 - notes: optional, string. Notes for this class. Can be used to keep questions
   or additional information.
-- source: mandatory, string. A short description where the informations for this
+- source: mandatory, string. A short description where the information for this
   class originate. Should contain a URL if possible.
 
 .. _class-name-element:
@@ -437,7 +437,7 @@ things) to populate the template given in the substitution-element_.
 Base File
 =========
 
-Base files are `yaml <http://yaml.org/>`_ files, in which informations about
+Base files are `yaml <http://yaml.org/>`_ files, in which information about
 the files for a collection in a database_ directory are stored. They consist of
 a list of base-file-element_, one for each file they describe.
 
@@ -446,13 +446,13 @@ a list of base-file-element_, one for each file they describe.
 Base file element
 -----------------
 
-A base file element is an associative array containing informations about a
+A base file element is an associative array containing information about a
 file. Depending on the type of the file the contained keys are different.
 However, there are some keys that are present in every base file element:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_.
 - type: mandatory, string. A string describing the type of the file.
@@ -485,7 +485,7 @@ See base-file-type-drawing-dimensions_ and base-file-type-drawing-connectors_.
 OpenSCAD
 ********
 
-The files containing all the informations necessary to build a geometrical
+The files containing all the information necessary to build a geometrical
 representation of a class in OpenSCAD  reside in the "openscad" directory. This
 database directory contains a folder for each collection_ which contains files
 related to this collection, and the folder is named like the collection-id.
@@ -496,8 +496,8 @@ and construct the part according to these dimensions. These modules are stored
 in one or several files residing in the respective collection directory within
 the openscad database directory
 
-In order to integrate the base modules properly, BOLTS needs informations about
-them. These informations are stored in the base-file_ of a collection, in form
+In order to integrate the base modules properly, BOLTS needs information about
+them. These information are stored in the base-file_ of a collection, in form
 of one base-file-element_ of type "modules" (see base-file-type-module_) for
 every file with one or more modules.
 
@@ -554,7 +554,7 @@ parameters of a part. It is an associative array with the following keys:
   Files with the same basename but different extensions are taken to be
   conversions to different file formats.
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_.
 - type: "drawing-dimensions"
@@ -576,7 +576,7 @@ the following keys:
   Files with the same basename but different extensions are taken to be
   conversions to different file formats.
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_.
 - type: "drawing-connectors"
@@ -596,7 +596,7 @@ It is an associative array that contains the following keys:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_
 - type: "module"
@@ -619,10 +619,10 @@ the following keys:
 - classids: mandatory, list of string. A list of class ids for which this base
   module should be used.
 - parameters: optional, parameter-element_: Additional basespecific parameters.
-  These parameters allow to represent additional paramters, which are not
+  These parameters allow to represent additional parameters, which are not
   specific to the class, but to the base. This allows e.g. to let the user
   choose  between a detailed and a schematic representation of the part.
-- connectors: optional, base-module-cs_. Informations about the connectors
+- connectors: optional, base-module-cs_. Information about the connectors
   attached to the part.
 
 .. _base-module-cs:
@@ -656,7 +656,7 @@ associative array with the following keys:
 
 - filename: mandatory, string. The filename of the file
 - author: mandatory, string or list of strings. The author of the file with
-  e-mail adress in <> or a list of several authors.
+  e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_.
 - type: "function"
@@ -674,7 +674,7 @@ with the following keys:
 - classids: mandatory, list of string. A list of class ids for which this base
   module should be used.
 - parameters: optional, parameter-element_: Additional basespecific parameters.
-  These parameters allow to represent additional paramters, which are not
+  These parameters allow to represent additional parameters, which are not
   specific to the class, but to the base. This allows e.g. to let the user
   choose  between a detailed and a schematic representation of the part.
 
@@ -690,7 +690,7 @@ create a design table that can be used together with a model file to create a
 
 - filename: mandatory, string. The filename of the SolidWorks model file
 - author: mandatory, string or list of strings. The author of the model file
-  with e-mail adress in <> or a list of several authors.
+  with e-mail address in <> or a list of several authors.
 - license: mandatory, string. The license of the file. Must be one of the
   supported-licenses_.
 - type: "solidworks"

--- a/backends/website/docs/static/0.3/specification_0_2.html
+++ b/backends/website/docs/static/0.3/specification_0_2.html
@@ -86,7 +86,7 @@ when the distribution is regenerated.</p>
 <div class="section" id="the-backend-directories">
 <h3>The backend directories</h3>
 <p>Each backend directory can contain files and directories with additional
-informations, which  are required by the backend. Details are specified by the
+information, which  are required by the backend. Details are specified by the
 <a class="reference internal" href="#backend">backend</a>.</p>
 </div>
 </div>
@@ -101,7 +101,7 @@ backend specific data. The former is held in <a class="reference internal" href=
 data as input and has one or several files as output. The output is called the
 distribution.</p>
 <img alt="processing.png" src="processing.png" style="width: 100%;" />
-<p>A example for a backend would be a process that uses the backend indepent data
+<p>A example for a backend would be a process that uses the backend independent data
 about parts, their geometries and dimensions together with a number of
 templates and stylesheets and produces a set of HTML pages with a nicely
 rendered, browsable description of the parts. Other backends could produce data
@@ -109,12 +109,12 @@ that is suitable for use in specific CAD applications.</p>
 <p>Often backends are relatively independent and do use only their own backend
 specific data. However, this is not necessarily so, a backend may also use
 backend specific data of other backends. For example the HTML backend described
-above might add informations about how to use a part in a specific CAD
+above might add information about how to use a part in a specific CAD
 application, and this might require to access the backend specific data of the
 backend for this CAD application. However, such cross backend dependencies
 should be made optional, to keep every backend functional independently of other
 backends.</p>
-<p>There is a <a class="reference internal" href="#list-of-backends">list-of-backends</a>, where more informations about the available
+<p>There is a <a class="reference internal" href="#list-of-backends">list-of-backends</a>, where more information about the available
 backends can be found and their <a class="reference internal" href="#base-files">base-files</a> are specified.</p>
 </div>
 <div class="section" id="backend-independent-data-the-blt-file">
@@ -134,7 +134,7 @@ descriptive, as they may be visible to the user. Some names can not be
 collection ids: common, gui, template</p>
 <div class="section" id="id2">
 <span id="collection-header"></span><h4>Collection header</h4>
-<p>The collection header is an associative array that holds general informations
+<p>The collection header is an associative array that holds general information
 regarding the <a class="reference internal" href="#collection">collection</a>. It contains the following keys:</p>
 <ul class="simple">
 <li>name: optional, string. A name for the collection.</li>
@@ -179,7 +179,7 @@ specifying standard.  In the case of several identical standards, a list of
 urls has to be given.</li>
 <li>notes: optional, string. Notes for this class. Can be used to formulate
 questions or additional information.</li>
-<li>source: mandatory, string. A short description where the informations for this
+<li>source: mandatory, string. A short description where the information for this
 class originate. Should contain a URL if possible.</li>
 </ul>
 </div>
@@ -305,13 +305,13 @@ data about additional files for a collection. They consist of a list of
 <a class="reference internal" href="#base-file-element">base-file-element</a>, one for each file they describe.</p>
 <div class="section" id="id10">
 <span id="base-file-element"></span><h4>Base file element</h4>
-<p>A base file element is an associative array containing informations about a
+<p>A base file element is an associative array containing information about a
 file. Depending on the type of the file the contained keys are different.
 However, there are some keys that are present in every base file element:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: mandatory, string. A string describing the type of the file.</li>
@@ -326,13 +326,13 @@ e-mail adress in &lt;&gt; or a list of several authors.</li>
 <span id="list-of-backends"></span><h1>List of Backends</h1>
 <div class="section" id="openscad">
 <h2>OpenSCAD</h2>
-<p>The files containing informations required by the OpenSCAD backend reside in
+<p>The files containing information required by the OpenSCAD backend reside in
 the backend directory with the name openscad. This backend directory contains a
 folder for each <a class="reference internal" href="#collection">collection</a> that contains files related to this collection, and
 the folder is named like the collection-id.</p>
 <p>The OpenSCAD backend generates a OpenSCAD library with modules for all parts
 from the collections.</p>
-<p>To be able to do that it needs informations about base modules, which are
+<p>To be able to do that it needs information about base modules, which are
 stored in the <a class="reference internal" href="#base-files">base-files</a> of a collection. Base modules are openscad modules
 that take as parameters a subset of all  the parameters of the part (see
 <a class="reference internal" href="#parameter-collection">parameter-collection</a>), and construct the part according to these dimensions.</p>
@@ -358,7 +358,7 @@ It is an associative array that contains the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a></li>
 <li>type: &quot;module&quot;</li>
@@ -377,7 +377,7 @@ parameters of the class, see <a class="reference internal" href="#parameter-coll
 <li>classids: mandatory, list of string. A list of class ids for which this base
 module should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
 </ul>
@@ -390,7 +390,7 @@ the STL format. It is an associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be either &quot;CC0
 1.0&quot; or &quot;Public Domain&quot;.</li>
 <li>type: &quot;stl&quot;</li>
@@ -406,7 +406,7 @@ associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;function&quot;</li>
@@ -421,7 +421,7 @@ with the following keys:</p>
 <li>classids: mandatory, list of string. A list of class ids for which this base
 module should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
 </ul>
@@ -434,7 +434,7 @@ associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be &quot;CC0 1.0&quot; or
 &quot;Public Domain&quot;.</li>
 <li>type: &quot;fcstd&quot;</li>
@@ -449,7 +449,7 @@ Document. It has the following keys:</p>
 <li>classids: mandatory, list of string. A list of class ids for which this base
 part should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
 <li>proptoparam: optional, associative array of associative arrays. This maps

--- a/backends/website/docs/static/0.3/specification_0_3.html
+++ b/backends/website/docs/static/0.3/specification_0_3.html
@@ -69,7 +69,7 @@ repository.</p>
 <span id="database"></span><h3>The databases</h3>
 <p>A database directory is a directory that contains data about certain aspects of
 the parts or data in a specific form.Backends can access this data to
-transform the parts data into specific forms or collect informations.</p>
+transform the parts data into specific forms or collect information.</p>
 <p>In contrast to the data in the <a class="reference internal" href="#blt-file">blt-file</a>, the data in the database directories
 is optional. If for a <a class="reference internal" href="#class">class</a> this data is not available, the <a class="reference internal" href="#backend">backend</a> has to be
 able to deal with it in an appropriate manner, for example by not processing
@@ -87,7 +87,7 @@ backend specific data. The former is held in <a class="reference internal" href=
 <a class="reference internal" href="#database">database</a>, transforms this data and outputs a set of files. This output is called
 the distribution.</p>
 <img alt="processing_0.3.png" src="processing_0.3.png" style="width: 100%;" />
-<p>Am example for a backend would be a process that uses the backend indepent data
+<p>Am example for a backend would be a process that uses the backend independent data
 about parts, their geometries and dimensions together with a number of
 templates and stylesheets and produces a set of HTML pages with a nicely
 rendered, browsable description of the parts. Other backends could produce data
@@ -101,7 +101,7 @@ the extension .blt. These files contain exactly one YAML document consisting of
 an associative array with the following keys:</p>
 <ul class="simple">
 <li>id: mandatory, string. The id of the collection. Must be identical to the
-filename of the blt file without the extenstion.</li>
+filename of the blt file without the extension.</li>
 <li>name: optional, string. A name for the collection.</li>
 <li>description: optional, string. A description of the contents of this
 collection.</li>
@@ -149,7 +149,7 @@ specifying standard.  In the case of several identical standards, a list of
 urls has to be given.</li>
 <li>notes: optional, string. Notes for this class. Can be used to keep questions
 or additional information.</li>
-<li>source: mandatory, string. A short description where the informations for this
+<li>source: mandatory, string. A short description where the information for this
 class originate. Should contain a URL if possible.</li>
 </ul>
 </div>
@@ -326,18 +326,18 @@ properties) to populate the template given in the <a class="reference internal" 
 </div>
 <div class="section" id="id8">
 <span id="base-files"></span><h3>Base Files</h3>
-<p>Base files are <a class="reference external" href="http://yaml.org/">yaml</a> files, in which informations about
+<p>Base files are <a class="reference external" href="http://yaml.org/">yaml</a> files, in which information about
 the files for a collection in a <a class="reference internal" href="#database">database</a> directory are stored. They consist of
 a list of <a class="reference internal" href="#base-file-element">base-file-element</a>, one for each file they describe.</p>
 <div class="section" id="id10">
 <span id="base-file-element"></span><h4>Base file element</h4>
-<p>A base file element is an associative array containing informations about a
+<p>A base file element is an associative array containing information about a
 file. Depending on the type of the file the contained keys are different.
 However, there are some keys that are present in every base file element:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: mandatory, string. A string describing the type of the file.</li>
@@ -363,12 +363,12 @@ See <a class="reference internal" href="#base-file-type-drawing-dimensions">base
 </div>
 <div class="section" id="openscad">
 <h2>OpenSCAD</h2>
-<p>The files containing all the informations necessary to build a geometrical
+<p>The files containing all the information necessary to build a geometrical
 representation of a class in OpenSCAD  reside in the &quot;openscad&quot; directory. This
 database directory contains a folder for each <a class="reference internal" href="#collection">collection</a> that contains files
 related to this collection, and the folder is named like the collection-id.</p>
-<p>To be able to do that it needs informations about base modules. These
-informations are stored in the <a class="reference internal" href="#base-files">base-files</a> of a collection. Base modules are
+<p>To be able to do that it needs information about base modules. These
+information are stored in the <a class="reference internal" href="#base-files">base-files</a> of a collection. Base modules are
 OpenSCAD modules that take as parameters a subset of the parameters of the
 part (see <a class="reference internal" href="#parameter-collection">parameter-collection</a>), and construct the part according to these
 dimensions.</p>
@@ -413,7 +413,7 @@ parameters of a part. It is an associative array with the following keys:</p>
 Files with the same basename but different extensions are taken to be
 conversions to different file formats.</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;drawing-dimensions&quot;</li>
@@ -431,7 +431,7 @@ the following keys:</p>
 Files with the same basename but different extensions are taken to be
 conversions to different file formats.</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;drawing-connectors&quot;</li>
@@ -448,7 +448,7 @@ It is an associative array that contains the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a></li>
 <li>type: &quot;module&quot;</li>
@@ -467,10 +467,10 @@ parameters of the class, see <a class="reference internal" href="#parameter-coll
 <li>classids: mandatory, list of string. A list of class ids for which this base
 module should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
-<li>connectors: optional, <a class="reference internal" href="#base-module-cs">base-module-cs</a>. Informations about the connectors
+<li>connectors: optional, <a class="reference internal" href="#base-module-cs">base-module-cs</a>. Information about the connectors
 attached to the part.</li>
 </ul>
 </div>
@@ -500,7 +500,7 @@ the STL format. It is an associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be either &quot;CC0
 1.0&quot; or &quot;Public Domain&quot;.</li>
 <li>type: &quot;stl&quot;</li>
@@ -516,7 +516,7 @@ associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;function&quot;</li>
@@ -531,7 +531,7 @@ with the following keys:</p>
 <li>classids: mandatory, list of string. A list of class ids for which this base
 module should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
 </ul>
@@ -544,7 +544,7 @@ associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be &quot;CC0 1.0&quot; or
 &quot;Public Domain&quot;.</li>
 <li>type: &quot;fcstd&quot;</li>
@@ -559,7 +559,7 @@ Document. It has the following keys:</p>
 <li>classids: mandatory, list of string. A list of class ids for which this base
 part should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
 <li>proptoparam: optional, associative array of associative arrays. This maps
@@ -579,7 +579,7 @@ create a design table that can be used together with a model file to create a
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the SolidWorks model file</li>
 <li>author: mandatory, string or list of strings. The author of the model file
-with e-mail adress in &lt;&gt; or a list of several authors.</li>
+with e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;solidworks&quot;</li>

--- a/backends/website/docs/static/0.3/specification_dev.html
+++ b/backends/website/docs/static/0.3/specification_dev.html
@@ -69,7 +69,7 @@ repository.</p>
 <span id="database"></span><h3>The databases</h3>
 <p>A database directory is a directory that contains data about certain aspects of
 the parts or data in a specific form.Backends can access this data to
-transform the parts data into specific forms or collect informations.</p>
+transform the parts data into specific forms or collect information.</p>
 <p>In contrast to the data in the <a class="reference internal" href="#blt-file">blt-file</a>, the data in the database directories
 is optional. If for a <a class="reference internal" href="#class">class</a> this data is not available, the <a class="reference internal" href="#backend">backend</a> has to be
 able to deal with it in an appropriate manner, for example by not processing
@@ -87,7 +87,7 @@ backend specific data. The former is held in <a class="reference internal" href=
 <a class="reference internal" href="#database">database</a>, transforms this data and outputs a set of files. This output is called
 the distribution.</p>
 <img alt="processing_0.3.png" src="processing_0.3.png" style="width: 100%;" />
-<p>Am example for a backend would be a process that uses the backend indepent data
+<p>Am example for a backend would be a process that uses the backend independent data
 about parts, their geometries and dimensions together with a number of
 templates and stylesheets and produces a set of HTML pages with a nicely
 rendered, browsable description of the parts. Other backends could produce data
@@ -101,7 +101,7 @@ the extension .blt. These files contain exactly one YAML document consisting of
 an associative array with the following keys:</p>
 <ul class="simple">
 <li>id: mandatory, string. The id of the collection. Must be identical to the
-filename of the blt file without the extenstion.</li>
+filename of the blt file without the extension.</li>
 <li>name: optional, string. A name for the collection.</li>
 <li>description: optional, string. A description of the contents of this
 collection.</li>
@@ -149,7 +149,7 @@ specifying standard.  In the case of several identical standards, a list of
 urls has to be given.</li>
 <li>notes: optional, string. Notes for this class. Can be used to keep questions
 or additional information.</li>
-<li>source: mandatory, string. A short description where the informations for this
+<li>source: mandatory, string. A short description where the information for this
 class originate. Should contain a URL if possible.</li>
 </ul>
 </div>
@@ -326,18 +326,18 @@ properties) to populate the template given in the <a class="reference internal" 
 </div>
 <div class="section" id="id8">
 <span id="base-files"></span><h3>Base Files</h3>
-<p>Base files are <a class="reference external" href="http://yaml.org/">yaml</a> files, in which informations about
+<p>Base files are <a class="reference external" href="http://yaml.org/">yaml</a> files, in which information about
 the files for a collection in a <a class="reference internal" href="#database">database</a> directory are stored. They consist of
 a list of <a class="reference internal" href="#base-file-element">base-file-element</a>, one for each file they describe.</p>
 <div class="section" id="id10">
 <span id="base-file-element"></span><h4>Base file element</h4>
-<p>A base file element is an associative array containing informations about a
+<p>A base file element is an associative array containing information about a
 file. Depending on the type of the file the contained keys are different.
 However, there are some keys that are present in every base file element:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: mandatory, string. A string describing the type of the file.</li>
@@ -363,12 +363,12 @@ See <a class="reference internal" href="#base-file-type-drawing-dimensions">base
 </div>
 <div class="section" id="openscad">
 <h2>OpenSCAD</h2>
-<p>The files containing all the informations necessary to build a geometrical
+<p>The files containing all the information necessary to build a geometrical
 representation of a class in OpenSCAD  reside in the &quot;openscad&quot; directory. This
 database directory contains a folder for each <a class="reference internal" href="#collection">collection</a> that contains files
 related to this collection, and the folder is named like the collection-id.</p>
-<p>To be able to do that it needs informations about base modules. These
-informations are stored in the <a class="reference internal" href="#base-files">base-files</a> of a collection. Base modules are
+<p>To be able to do that it needs information about base modules. These
+information are stored in the <a class="reference internal" href="#base-files">base-files</a> of a collection. Base modules are
 OpenSCAD modules that take as parameters a subset of the parameters of the
 part (see <a class="reference internal" href="#parameter-collection">parameter-collection</a>), and construct the part according to these
 dimensions.</p>
@@ -411,7 +411,7 @@ parameters of a part. It is an associative array with the following keys:</p>
 Files with the same basename but different extensions are taken to be
 conversions to different file formats.</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;drawing-dimensions&quot;</li>
@@ -429,7 +429,7 @@ the following keys:</p>
 Files with the same basename but different extensions are taken to be
 conversions to different file formats.</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;drawing-connectors&quot;</li>
@@ -446,7 +446,7 @@ It is an associative array that contains the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a></li>
 <li>type: &quot;module&quot;</li>
@@ -465,10 +465,10 @@ parameters of the class, see <a class="reference internal" href="#parameter-coll
 <li>classids: mandatory, list of string. A list of class ids for which this base
 module should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
-<li>connectors: optional, <a class="reference internal" href="#base-module-cs">base-module-cs</a>. Informations about the connectors
+<li>connectors: optional, <a class="reference internal" href="#base-module-cs">base-module-cs</a>. Information about the connectors
 attached to the part.</li>
 </ul>
 </div>
@@ -499,7 +499,7 @@ associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;function&quot;</li>
@@ -514,7 +514,7 @@ with the following keys:</p>
 <li>classids: mandatory, list of string. A list of class ids for which this base
 module should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
 </ul>
@@ -528,7 +528,7 @@ create a design table that can be used together with a model file to create a
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the SolidWorks model file</li>
 <li>author: mandatory, string or list of strings. The author of the model file
-with e-mail adress in &lt;&gt; or a list of several authors.</li>
+with e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;solidworks&quot;</li>

--- a/backends/website/docs/static/0.4/specification_0_2.html
+++ b/backends/website/docs/static/0.4/specification_0_2.html
@@ -86,7 +86,7 @@ when the distribution is regenerated.</p>
 <div class="section" id="the-backend-directories">
 <h3>The backend directories</h3>
 <p>Each backend directory can contain files and directories with additional
-informations, which  are required by the backend. Details are specified by the
+information, which  are required by the backend. Details are specified by the
 <a class="reference internal" href="#backend">backend</a>.</p>
 </div>
 </div>
@@ -101,7 +101,7 @@ backend specific data. The former is held in <a class="reference internal" href=
 data as input and has one or several files as output. The output is called the
 distribution.</p>
 <img alt="processing.png" src="processing.png" style="width: 100%;" />
-<p>A example for a backend would be a process that uses the backend indepent data
+<p>A example for a backend would be a process that uses the backend independent data
 about parts, their geometries and dimensions together with a number of
 templates and stylesheets and produces a set of HTML pages with a nicely
 rendered, browsable description of the parts. Other backends could produce data
@@ -109,12 +109,12 @@ that is suitable for use in specific CAD applications.</p>
 <p>Often backends are relatively independent and do use only their own backend
 specific data. However, this is not necessarily so, a backend may also use
 backend specific data of other backends. For example the HTML backend described
-above might add informations about how to use a part in a specific CAD
+above might add information about how to use a part in a specific CAD
 application, and this might require to access the backend specific data of the
 backend for this CAD application. However, such cross backend dependencies
 should be made optional, to keep every backend functional independently of other
 backends.</p>
-<p>There is a <a class="reference internal" href="#list-of-backends">list-of-backends</a>, where more informations about the available
+<p>There is a <a class="reference internal" href="#list-of-backends">list-of-backends</a>, where more information about the available
 backends can be found and their <a class="reference internal" href="#base-files">base-files</a> are specified.</p>
 </div>
 <div class="section" id="backend-independent-data-the-blt-file">
@@ -134,7 +134,7 @@ descriptive, as they may be visible to the user. Some names can not be
 collection ids: common, gui, template</p>
 <div class="section" id="id2">
 <span id="collection-header"></span><h4>Collection header</h4>
-<p>The collection header is an associative array that holds general informations
+<p>The collection header is an associative array that holds general information
 regarding the <a class="reference internal" href="#collection">collection</a>. It contains the following keys:</p>
 <ul class="simple">
 <li>name: optional, string. A name for the collection.</li>
@@ -179,7 +179,7 @@ specifying standard.  In the case of several identical standards, a list of
 urls has to be given.</li>
 <li>notes: optional, string. Notes for this class. Can be used to formulate
 questions or additional information.</li>
-<li>source: mandatory, string. A short description where the informations for this
+<li>source: mandatory, string. A short description where the information for this
 class originate. Should contain a URL if possible.</li>
 </ul>
 </div>
@@ -305,13 +305,13 @@ data about additional files for a collection. They consist of a list of
 <a class="reference internal" href="#base-file-element">base-file-element</a>, one for each file they describe.</p>
 <div class="section" id="id10">
 <span id="base-file-element"></span><h4>Base file element</h4>
-<p>A base file element is an associative array containing informations about a
+<p>A base file element is an associative array containing information about a
 file. Depending on the type of the file the contained keys are different.
 However, there are some keys that are present in every base file element:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: mandatory, string. A string describing the type of the file.</li>
@@ -326,13 +326,13 @@ e-mail adress in &lt;&gt; or a list of several authors.</li>
 <span id="list-of-backends"></span><h1>List of Backends</h1>
 <div class="section" id="openscad">
 <h2>OpenSCAD</h2>
-<p>The files containing informations required by the OpenSCAD backend reside in
+<p>The files containing information required by the OpenSCAD backend reside in
 the backend directory with the name openscad. This backend directory contains a
 folder for each <a class="reference internal" href="#collection">collection</a> that contains files related to this collection, and
 the folder is named like the collection-id.</p>
 <p>The OpenSCAD backend generates a OpenSCAD library with modules for all parts
 from the collections.</p>
-<p>To be able to do that it needs informations about base modules, which are
+<p>To be able to do that it needs information about base modules, which are
 stored in the <a class="reference internal" href="#base-files">base-files</a> of a collection. Base modules are openscad modules
 that take as parameters a subset of all  the parameters of the part (see
 <a class="reference internal" href="#parameter-collection">parameter-collection</a>), and construct the part according to these dimensions.</p>
@@ -358,7 +358,7 @@ It is an associative array that contains the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a></li>
 <li>type: &quot;module&quot;</li>
@@ -377,7 +377,7 @@ parameters of the class, see <a class="reference internal" href="#parameter-coll
 <li>classids: mandatory, list of string. A list of class ids for which this base
 module should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
 </ul>
@@ -390,7 +390,7 @@ the STL format. It is an associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be either &quot;CC0
 1.0&quot; or &quot;Public Domain&quot;.</li>
 <li>type: &quot;stl&quot;</li>
@@ -406,7 +406,7 @@ associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;function&quot;</li>
@@ -421,7 +421,7 @@ with the following keys:</p>
 <li>classids: mandatory, list of string. A list of class ids for which this base
 module should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
 </ul>
@@ -434,7 +434,7 @@ associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be &quot;CC0 1.0&quot; or
 &quot;Public Domain&quot;.</li>
 <li>type: &quot;fcstd&quot;</li>
@@ -449,7 +449,7 @@ Document. It has the following keys:</p>
 <li>classids: mandatory, list of string. A list of class ids for which this base
 part should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
 <li>proptoparam: optional, associative array of associative arrays. This maps

--- a/backends/website/docs/static/0.4/specification_0_3.html
+++ b/backends/website/docs/static/0.4/specification_0_3.html
@@ -69,7 +69,7 @@ repository.</p>
 <span id="database"></span><h3>The databases</h3>
 <p>A database directory is a directory that contains data about certain aspects of
 the parts or data in a specific form.Backends can access this data to
-transform the parts data into specific forms or collect informations.</p>
+transform the parts data into specific forms or collect information.</p>
 <p>In contrast to the data in the <a class="reference internal" href="#blt-file">blt-file</a>, the data in the database directories
 is optional. If for a <a class="reference internal" href="#class">class</a> this data is not available, the <a class="reference internal" href="#backend">backend</a> has to be
 able to deal with it in an appropriate manner, for example by not processing
@@ -87,7 +87,7 @@ backend specific data. The former is held in <a class="reference internal" href=
 <a class="reference internal" href="#database">database</a>, transforms this data and outputs a set of files. This output is called
 the distribution.</p>
 <img alt="processing_0.3.png" src="processing_0.3.png" style="width: 100%;" />
-<p>Am example for a backend would be a process that uses the backend indepent data
+<p>Am example for a backend would be a process that uses the backend independent data
 about parts, their geometries and dimensions together with a number of
 templates and stylesheets and produces a set of HTML pages with a nicely
 rendered, browsable description of the parts. Other backends could produce data
@@ -101,7 +101,7 @@ the extension .blt. These files contain exactly one YAML document consisting of
 an associative array with the following keys:</p>
 <ul class="simple">
 <li>id: mandatory, string. The id of the collection. Must be identical to the
-filename of the blt file without the extenstion.</li>
+filename of the blt file without the extension.</li>
 <li>name: optional, string. A name for the collection.</li>
 <li>description: optional, string. A description of the contents of this
 collection.</li>
@@ -149,7 +149,7 @@ specifying standard.  In the case of several identical standards, a list of
 urls has to be given.</li>
 <li>notes: optional, string. Notes for this class. Can be used to keep questions
 or additional information.</li>
-<li>source: mandatory, string. A short description where the informations for this
+<li>source: mandatory, string. A short description where the information for this
 class originate. Should contain a URL if possible.</li>
 </ul>
 </div>
@@ -326,18 +326,18 @@ properties) to populate the template given in the <a class="reference internal" 
 </div>
 <div class="section" id="id8">
 <span id="base-files"></span><h3>Base Files</h3>
-<p>Base files are <a class="reference external" href="http://yaml.org/">yaml</a> files, in which informations about
+<p>Base files are <a class="reference external" href="http://yaml.org/">yaml</a> files, in which information about
 the files for a collection in a <a class="reference internal" href="#database">database</a> directory are stored. They consist of
 a list of <a class="reference internal" href="#base-file-element">base-file-element</a>, one for each file they describe.</p>
 <div class="section" id="id10">
 <span id="base-file-element"></span><h4>Base file element</h4>
-<p>A base file element is an associative array containing informations about a
+<p>A base file element is an associative array containing information about a
 file. Depending on the type of the file the contained keys are different.
 However, there are some keys that are present in every base file element:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: mandatory, string. A string describing the type of the file.</li>
@@ -363,12 +363,12 @@ See <a class="reference internal" href="#base-file-type-drawing-dimensions">base
 </div>
 <div class="section" id="openscad">
 <h2>OpenSCAD</h2>
-<p>The files containing all the informations necessary to build a geometrical
+<p>The files containing all the information necessary to build a geometrical
 representation of a class in OpenSCAD  reside in the &quot;openscad&quot; directory. This
 database directory contains a folder for each <a class="reference internal" href="#collection">collection</a> that contains files
 related to this collection, and the folder is named like the collection-id.</p>
-<p>To be able to do that it needs informations about base modules. These
-informations are stored in the <a class="reference internal" href="#base-files">base-files</a> of a collection. Base modules are
+<p>To be able to do that it needs information about base modules. These
+information are stored in the <a class="reference internal" href="#base-files">base-files</a> of a collection. Base modules are
 OpenSCAD modules that take as parameters a subset of the parameters of the
 part (see <a class="reference internal" href="#parameter-collection">parameter-collection</a>), and construct the part according to these
 dimensions.</p>
@@ -413,7 +413,7 @@ parameters of a part. It is an associative array with the following keys:</p>
 Files with the same basename but different extensions are taken to be
 conversions to different file formats.</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;drawing-dimensions&quot;</li>
@@ -431,7 +431,7 @@ the following keys:</p>
 Files with the same basename but different extensions are taken to be
 conversions to different file formats.</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;drawing-connectors&quot;</li>
@@ -448,7 +448,7 @@ It is an associative array that contains the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a></li>
 <li>type: &quot;module&quot;</li>
@@ -467,10 +467,10 @@ parameters of the class, see <a class="reference internal" href="#parameter-coll
 <li>classids: mandatory, list of string. A list of class ids for which this base
 module should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
-<li>connectors: optional, <a class="reference internal" href="#base-module-cs">base-module-cs</a>. Informations about the connectors
+<li>connectors: optional, <a class="reference internal" href="#base-module-cs">base-module-cs</a>. Information about the connectors
 attached to the part.</li>
 </ul>
 </div>
@@ -500,7 +500,7 @@ the STL format. It is an associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be either &quot;CC0
 1.0&quot; or &quot;Public Domain&quot;.</li>
 <li>type: &quot;stl&quot;</li>
@@ -516,7 +516,7 @@ associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;function&quot;</li>
@@ -531,7 +531,7 @@ with the following keys:</p>
 <li>classids: mandatory, list of string. A list of class ids for which this base
 module should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
 </ul>
@@ -544,7 +544,7 @@ associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be &quot;CC0 1.0&quot; or
 &quot;Public Domain&quot;.</li>
 <li>type: &quot;fcstd&quot;</li>
@@ -559,7 +559,7 @@ Document. It has the following keys:</p>
 <li>classids: mandatory, list of string. A list of class ids for which this base
 part should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
 <li>proptoparam: optional, associative array of associative arrays. This maps
@@ -579,7 +579,7 @@ create a design table that can be used together with a model file to create a
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the SolidWorks model file</li>
 <li>author: mandatory, string or list of strings. The author of the model file
-with e-mail adress in &lt;&gt; or a list of several authors.</li>
+with e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;solidworks&quot;</li>

--- a/backends/website/docs/static/0.4/specification_dev.html
+++ b/backends/website/docs/static/0.4/specification_dev.html
@@ -69,7 +69,7 @@ repository.</p>
 <span id="database"></span><h3>The databases</h3>
 <p>A database directory is a directory that contains data about certain aspects of
 the parts or data in a specific form.Backends can access this data to
-transform the parts data into specific forms or collect informations.</p>
+transform the parts data into specific forms or collect information.</p>
 <p>In contrast to the data in the <a class="reference internal" href="#blt-file">blt-file</a>, the data in the database directories
 is optional. If for a <a class="reference internal" href="#class">class</a> this data is not available, the <a class="reference internal" href="#backend">backend</a> has to be
 able to deal with it in an appropriate manner, for example by not processing
@@ -87,7 +87,7 @@ backend specific data. The former is held in <a class="reference internal" href=
 <a class="reference internal" href="#database">database</a>, transforms this data and outputs a set of files. This output is called
 the distribution.</p>
 <img alt="processing_0.3.png" src="processing_0.3.png" style="width: 100%;" />
-<p>Am example for a backend would be a process that uses the backend indepent data
+<p>Am example for a backend would be a process that uses the backend independent data
 about parts, their geometries and dimensions together with a number of
 templates and stylesheets and produces a set of HTML pages with a nicely
 rendered, browsable description of the parts. Other backends could produce data
@@ -101,7 +101,7 @@ the extension .blt. These files contain exactly one YAML document consisting of
 an associative array with the following keys:</p>
 <ul class="simple">
 <li>id: mandatory, string. The id of the collection. Must be identical to the
-filename of the blt file without the extenstion.</li>
+filename of the blt file without the extension.</li>
 <li>name: optional, string. A name for the collection.</li>
 <li>description: optional, string. A description of the contents of this
 collection.</li>
@@ -149,7 +149,7 @@ specifying standard.  In the case of several identical standards, a list of
 urls has to be given.</li>
 <li>notes: optional, string. Notes for this class. Can be used to keep questions
 or additional information.</li>
-<li>source: mandatory, string. A short description where the informations for this
+<li>source: mandatory, string. A short description where the information for this
 class originate. Should contain a URL if possible.</li>
 </ul>
 </div>
@@ -326,18 +326,18 @@ properties) to populate the template given in the <a class="reference internal" 
 </div>
 <div class="section" id="id8">
 <span id="base-files"></span><h3>Base Files</h3>
-<p>Base files are <a class="reference external" href="http://yaml.org/">yaml</a> files, in which informations about
+<p>Base files are <a class="reference external" href="http://yaml.org/">yaml</a> files, in which information about
 the files for a collection in a <a class="reference internal" href="#database">database</a> directory are stored. They consist of
 a list of <a class="reference internal" href="#base-file-element">base-file-element</a>, one for each file they describe.</p>
 <div class="section" id="id10">
 <span id="base-file-element"></span><h4>Base file element</h4>
-<p>A base file element is an associative array containing informations about a
+<p>A base file element is an associative array containing information about a
 file. Depending on the type of the file the contained keys are different.
 However, there are some keys that are present in every base file element:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: mandatory, string. A string describing the type of the file.</li>
@@ -363,12 +363,12 @@ See <a class="reference internal" href="#base-file-type-drawing-dimensions">base
 </div>
 <div class="section" id="openscad">
 <h2>OpenSCAD</h2>
-<p>The files containing all the informations necessary to build a geometrical
+<p>The files containing all the information necessary to build a geometrical
 representation of a class in OpenSCAD  reside in the &quot;openscad&quot; directory. This
 database directory contains a folder for each <a class="reference internal" href="#collection">collection</a> that contains files
 related to this collection, and the folder is named like the collection-id.</p>
-<p>To be able to do that it needs informations about base modules. These
-informations are stored in the <a class="reference internal" href="#base-files">base-files</a> of a collection. Base modules are
+<p>To be able to do that it needs information about base modules. These
+information are stored in the <a class="reference internal" href="#base-files">base-files</a> of a collection. Base modules are
 OpenSCAD modules that take as parameters a subset of the parameters of the
 part (see <a class="reference internal" href="#parameter-collection">parameter-collection</a>), and construct the part according to these
 dimensions.</p>
@@ -411,7 +411,7 @@ parameters of a part. It is an associative array with the following keys:</p>
 Files with the same basename but different extensions are taken to be
 conversions to different file formats.</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;drawing-dimensions&quot;</li>
@@ -429,7 +429,7 @@ the following keys:</p>
 Files with the same basename but different extensions are taken to be
 conversions to different file formats.</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;drawing-connectors&quot;</li>
@@ -446,7 +446,7 @@ It is an associative array that contains the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a></li>
 <li>type: &quot;module&quot;</li>
@@ -465,10 +465,10 @@ parameters of the class, see <a class="reference internal" href="#parameter-coll
 <li>classids: mandatory, list of string. A list of class ids for which this base
 module should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
-<li>connectors: optional, <a class="reference internal" href="#base-module-cs">base-module-cs</a>. Informations about the connectors
+<li>connectors: optional, <a class="reference internal" href="#base-module-cs">base-module-cs</a>. Information about the connectors
 attached to the part.</li>
 </ul>
 </div>
@@ -499,7 +499,7 @@ associative array with the following keys:</p>
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the file</li>
 <li>author: mandatory, string or list of strings. The author of the file with
-e-mail adress in &lt;&gt; or a list of several authors.</li>
+e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;function&quot;</li>
@@ -514,7 +514,7 @@ with the following keys:</p>
 <li>classids: mandatory, list of string. A list of class ids for which this base
 module should be used.</li>
 <li>parameters: optional, <a class="reference internal" href="#parameter-element">parameter-element</a>: Additional basespecific parameters.
-These parameters allow to represent additional paramters, which are not
+These parameters allow to represent additional parameters, which are not
 specific to the class, but to the base. This allows e.g. to let the user
 choose  between a detailed and a schematic representation of the part.</li>
 </ul>
@@ -528,7 +528,7 @@ create a design table that can be used together with a model file to create a
 <ul class="simple">
 <li>filename: mandatory, string. The filename of the SolidWorks model file</li>
 <li>author: mandatory, string or list of strings. The author of the model file
-with e-mail adress in &lt;&gt; or a list of several authors.</li>
+with e-mail address in &lt;&gt; or a list of several authors.</li>
 <li>license: mandatory, string. The license of the file. Must be one of the
 <a class="reference internal" href="#supported-licenses">supported-licenses</a>.</li>
 <li>type: &quot;solidworks&quot;</li>

--- a/backends/website/main/templates/contribute.html
+++ b/backends/website/main/templates/contribute.html
@@ -31,7 +31,7 @@
   <div class="col-md-4 col-xs-12">
     <h3>{% trans %}Improve data{% endtrans %}</h3>
 
-    <p>{% trans url = url_for('main.tasks') %}BOLTS scans its database for inconsistencies, common problems, missing or unclear informations and automatically generates <a href="{{ url }}">a list of things that could be fixed or improved</a>. This is a great starting point for contributing to BOLTS.{% endtrans %}</p>
+    <p>{% trans url = url_for('main.tasks') %}BOLTS scans its database for inconsistencies, common problems, missing or unclear information and automatically generates <a href="{{ url }}">a list of things that could be fixed or improved</a>. This is a great starting point for contributing to BOLTS.{% endtrans %}</p>
     <p>{% trans %}If you notice errors, translation problems or other problems on the website, you can directly report them using the comment field embedded in many pages.{% endtrans %}</p>
   </div>
 </div>

--- a/backends/website/main/templates/contributors.html
+++ b/backends/website/main/templates/contributors.html
@@ -32,7 +32,7 @@
       <tr><td><a href="http://shop.arcol.hu/">arcol</a></td><td>{% trans %}found the fix for a tricky bug and provided a lot of feedback.{% endtrans %}</td></tr>
       <tr><td>Dale Dunn</td><td>{% trans %}helped with the development of the SolidWorks flavour of BOLTS.{% endtrans %}</td></tr>
       <tr><td>Stefan Bühler</td><td>{% trans %}for his help with hosting and his general expertise.{% endtrans %}</td></tr>
-      <tr><td>Bernd Hahnebach</td><td>{% trans %}for his persistance, patience and for the maintainence and improvement of the FreeCAD integration.{% endtrans %}</td></tr>
+      <tr><td>Bernd Hahnebach</td><td>{% trans %}for his persistence, patience and for the maintenance and improvement of the FreeCAD integration.{% endtrans %}</td></tr>
     </table>
   </div>
 </div>

--- a/backends/website/parts/templates/parts/name.html
+++ b/backends/website/parts/templates/parts/name.html
@@ -21,7 +21,7 @@
 {% if not freecad is none %}
 {{ freecad.props }}
 {% else %}
-<p>{% trans %}This part is not availaible for FreeCAD{% endtrans %}</p>
+<p>{% trans %}This part is not available for FreeCAD{% endtrans %}</p>
 {% endif %}
 
 <h2>OpenSCAD</h2>
@@ -34,7 +34,7 @@
 <h3>{% trans %}Connectors{% endtrans %}</h3>
   {{ openscad.connectors }}
 {% else %}
-<p>{% trans %}This part is not availaible for OpenSCAD{% endtrans %}</p>
+<p>{% trans %}This part is not available for OpenSCAD{% endtrans %}</p>
 {% endif %}
 
 <h2>{% trans %}Tables{% endtrans %}</h2>

--- a/backends/website/parts/templates/parts/standard.html
+++ b/backends/website/parts/templates/parts/standard.html
@@ -19,7 +19,7 @@
 {% if not freecad is none %}
 {{ freecad.props }}
 {% else %}
-<p>{% trans %}This part is not availaible for FreeCAD{% endtrans %}</p>
+<p>{% trans %}This part is not available for FreeCAD{% endtrans %}</p>
 {% endif %}
 
 <h2>OpenSCAD</h2>
@@ -32,7 +32,7 @@
   <h3>{% trans %}Connectors{% endtrans %}</h3>
   {{ openscad.connectors }}
 {% else %}
-<p>{% trans %}This part is not availaible for OpenSCAD{% endtrans %}</p>
+<p>{% trans %}This part is not available for OpenSCAD{% endtrans %}</p>
 {% endif %}
 
 <h2>{% trans %}Tables{% endtrans %}</h2>

--- a/bolttools/yaml_in_yaml.py
+++ b/bolttools/yaml_in_yaml.py
@@ -1,5 +1,5 @@
 # ****************************************************************************
-# License only applys to this module
+# License only applies to this module
 #
 # MIT License
 #

--- a/data/profile_hollow.blt
+++ b/data/profile_hollow.blt
@@ -72,7 +72,7 @@ classes:
   source: No source information used
 - id: hollow_circle
   names:
-    description: Hot finised structural circular hollow sections of non-alloy and
+    description: Hot finished structural circular hollow sections of non-alloy and
       fine grain steel
     labeling: '%(type)s, l=%(l)s'
     name: Circular Hollow Section (CHS)
@@ -112,7 +112,7 @@ classes:
     year: 2006
 - id: hollow_square
   names:
-    description: Hot finised structural square hollow sections of non-alloy and fine
+    description: Hot finished structural square hollow sections of non-alloy and fine
       grain steel
     labeling: '%(type)s, l=%(l)s'
     name: Square Hollow Section (SHS)
@@ -152,7 +152,7 @@ classes:
     year: 2006
 - id: hollow_rectangular
   names:
-    description: Hot finised structural rectangular hollow sections of non-alloy and
+    description: Hot finished structural rectangular hollow sections of non-alloy and
       fine grain steel
     labeling: '%(type)s, l=%(l)s'
     name: Rectangular Hollow Section (RHS)

--- a/data/profile_l.blt
+++ b/data/profile_l.blt
@@ -71,7 +71,7 @@ classes:
       l: 1000
       type: LNP50x30x5
     description:
-      a: beam heigth
+      a: beam height
       b: beam width
       l: beam length
       r1: inner fillet radius

--- a/data/vacuum.blt
+++ b/data/vacuum.blt
@@ -77,8 +77,8 @@ classes:
           flangeDiameter: The diameter of the flange
           flangeSize: The thickness of the flange
           grooveRadius: The radius of the flange
-          openingDiameter: The diameter of the opening in the part visibl from the side of the flange
-          openingDepth: The depthd of the opening in the part visibl from the side of the flange
+          openingDiameter: The diameter of the opening in the part visible from the side of the flange
+          openingDepth: The depthd of the opening in the part visible from the side of the flange
           holeDiameter: The diameters of the central hole, use zero is the hole is unneeded
           holeTrDiameter: The diameter of the circumference the holes for fasteners are placed on
         tables:

--- a/freecad/profile_l/profile_l.py
+++ b/freecad/profile_l/profile_l.py
@@ -47,7 +47,7 @@ equallnp(my_test_params, App.ActiveDocument)
 
 def lbeam_parallel_flange_equal(params, document):
     # use unequal method for equals too
-    # we just need te define params["b"], which equal to params["a"] for equals LNP
+    # we just need to define params["b"], which equal to params["a"] for equals LNP
     params["b"] = params["a"]
     lbeam_parallel_flange_unequal(params, document)
 


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,./backends/website/static/source/bootstrap* -L medias,nd,sortings,technik,ure,varius`